### PR TITLE
Fix leave message is never edited

### DIFF
--- a/src/commands/leave.ts
+++ b/src/commands/leave.ts
@@ -18,7 +18,8 @@ export async function handler(
   if (!pipeline) {
     throw new ReplyableError("ボイスチャンネルに参加していません。");
   }
-  pipeline.connection.destroy();
+  // State change to `destoryed` is done synchronously.
+  setImmediate(() => pipeline.connection.destroy());
   await Promise.all([interaction.deferReply(), once(pipeline, "destroy")]);
   await interaction.editReply("退出しました。");
 }


### PR DESCRIPTION
editReplyに到達せず，メッセージがdeferのままになってしまう問題がありました．
問題はstateChangeは同期的に呼ばれるところにあったようですので，setImmediateで対応しました．
（コメントの英語が不自然かもしれないので，代案を歓迎します）

https://github.com/discordjs/discord.js/blob/ce0be392d818b13ba5a081811519b559202cdba8/packages/voice/src/VoiceConnection.ts#L564-L566