### PR TITLE
Pin to Node.js 18.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18 AS deps
+FROM node:18.18.2 AS deps
 ARG NODE_ENV=production
 WORKDIR /app
 COPY ./package*.json ./
 RUN npm ci
 
-FROM node:18 AS builder
+FROM node:18.18.2 AS builder
 ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./


### PR DESCRIPTION
18.19.0 では npm v10.2.3 がバンドルされているため、
GitHub Actions 上でのコンテナ構築に失敗するから。