### PR TITLE
Update node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18.18.2 AS deps
+FROM node:18.19.0 AS deps
 ARG NODE_ENV=production
 WORKDIR /app
 COPY ./package*.json ./
 RUN npm ci
 
-FROM node:18.18.2 AS builder
+FROM node:18.19.0 AS builder
 ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./
 COPY ./package*.json ./
-RUN npm ci
+RUN npm i -g npm@10.2.5 && npm ci
 COPY ./src/ ./src/
 RUN npm run build
 


### PR DESCRIPTION
Node.jsをv18.19.0にアップデートします．
v18.18.2とv18.19.0の間にnpmがアップデートされたことで，「arm64かつNODE_ENV=development」の場合にビルドが成功しない問題が出ていました．原因はわからないものの，npmを10.2.4以降にすることで解決したため，そのようにしています．