### PR TITLE
Update node.js (& shorten build time)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18.18.2 AS deps
+FROM node:18.19.0 AS deps
 ARG NODE_ENV=production
 WORKDIR /app
 COPY ./package*.json ./
 RUN npm ci
 
-FROM node:18.18.2 AS builder
+FROM node:18.19.0 AS builder
 ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY ./package*.json ./
 RUN npm ci
 
-FROM node:18.19.0 AS builder
+FROM --platform=$BUILDPLATFORM node:18.19.0 AS builder
 ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./
@@ -15,7 +15,7 @@ RUN npm ci
 COPY ./src/ ./src/
 RUN npm run build
 
-FROM node:18 AS model-fetch
+FROM --platform=$BUILDPLATFORM node:18 AS model-fetch
 
 WORKDIR /app
 RUN wget https://github.com/jpreprocess/jpreprocess/releases/download/v0.6.1/naist-jdic-jpreprocess.tar.gz \


### PR DESCRIPTION
builderステップ，model-fetchステップはアーキテクチャ依存のファイルを含まないため，ビルド環境のアーキテクチャのみで実行すれば十分です．qemuでビルドされる部分を減らすことで，ビルド時間を短縮します．