### PR TITLE
build: update node to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - name: Install dependencies
         run: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18.19.0 AS deps
+FROM node:20.10.0-bookworm AS deps
 ARG NODE_ENV=production
 WORKDIR /app
 COPY ./package*.json ./
 RUN npm ci
 
-FROM --platform=$BUILDPLATFORM node:18.19.0 AS builder
+FROM --platform=$BUILDPLATFORM node:20.10.0-bookworm AS builder
 ARG NODE_ENV=development
 WORKDIR /app
 COPY ./build.js ./
@@ -15,7 +15,7 @@ RUN npm ci
 COPY ./src/ ./src/
 RUN npm run build
 
-FROM --platform=$BUILDPLATFORM node:18 AS model-fetch
+FROM --platform=$BUILDPLATFORM node:20.10.0-bookworm AS model-fetch
 
 WORKDIR /app
 RUN wget https://github.com/jpreprocess/jpreprocess/releases/download/v0.6.1/naist-jdic-jpreprocess.tar.gz \
@@ -25,7 +25,7 @@ RUN wget http://downloads.sourceforge.net/open-jtalk/hts_voice_nitech_jp_atr503_
     && tar xzf hts_voice_nitech_jp_atr503_m001-1.05.tar.gz \
     && rm hts_voice_nitech_jp_atr503_m001-1.05.tar.gz
 
-FROM gcr.io/distroless/nodejs18-debian12:nonroot AS runner
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY ./package.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "sodium-native": "^4.0.4"
       },
       "devDependencies": {
-        "@types/node": "18",
+        "@types/node": "20",
         "@typescript-eslint/eslint-plugin": "^6.7.5",
         "@typescript-eslint/parser": "^6.7.5",
         "dotenv": "^16.3.1",
@@ -755,9 +755,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.5.tgz",
-      "integrity": "sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A=="
+      "version": "20.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -4375,6 +4378,11 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Discord.js Japan User Group (discordjs-japan.org)",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18",
+    "@types/node": "20",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
Closes #18 

Release-As: 0.1.1

debian 12を採用していることによりopusのprebuildが利用できていないため，実はNode 20に上げても上げなくてもopusのビルドは走っていたようです．

なお，`20.10.0`ではなく`20.10.0-bookworm`としたのは，depsステージでもdebian 12を使わせるためです．現在は最新版がbookwormなので違いはありませんが，今後新しいバージョンが出てきたときに壊れないよう，bookwormに固定します．