### PR TITLE
ci: restrict release workflow to discordjs-japan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release-please:
+    if: github.repository_owner == 'discordjs-japan'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
このリポジトリ以外でリリース処理を行う場合、リリースに関係する記載を書き換えるはずであるしそうして然るべきである。
それ故、このワークフローは discordjs-japan org 内でのみ動くようにするとともに、ここでその旨を明確にする。