### PR TITLE
chore: disable pin digests for docker/dockerfile

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -20,6 +20,12 @@
       "matchDepTypes": ["dependencies", "require"],
       "semanticCommitType": "deps",
       "semanticCommitScope": null
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["docker/dockerfile"],
+      "matchDepTypes": "syntax",
+      "pinDigests": false
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1@sha256:ac85f380a63b13dfcefa89046420e1781752bab202122f8f50032edf31be0021
+# syntax=docker/dockerfile:1
 
 FROM node:20.10.0-bookworm AS deps
 ARG NODE_ENV=production


### PR DESCRIPTION
これは構文解析用なので、digest で pin されている必要はない。