### PR TITLE
fix: improper handling voice connection status change

### DIFF
--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -37,6 +37,9 @@ export async function handler(
       "ボイスチャンネルに参加するか、チャンネルを指定してください。",
     );
   }
+  if (Pipeline.get(channel.guildId) != null) {
+    throw new ReplyableError("すでにボイスチャンネルに接続しています。");
+  }
   const pipeline = new Pipeline(channel);
   await Promise.all([interaction.deferReply(), once(pipeline, "ready")]);
   await interaction.editReply(`${channel}に参加しました。`);

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -1,4 +1,5 @@
 import { once } from "events";
+import { VoiceConnectionStatus } from "@discordjs/voice";
 import {
   ApplicationCommandOptionType,
   type ChatInputCommandInteraction,
@@ -41,6 +42,32 @@ export async function handler(
     throw new ReplyableError("すでにボイスチャンネルに接続しています。");
   }
   const pipeline = new Pipeline(channel);
-  await Promise.all([interaction.deferReply(), once(pipeline, "ready")]);
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+  setTimeout(() => {
+    abortController.abort();
+  }, 15_000);
+  await Promise.all([
+    interaction.deferReply(),
+    once(pipeline, "ready", {
+      signal,
+    }).catch((err) => {
+      if (
+        pipeline.connection.state.status !== VoiceConnectionStatus.Destroyed
+      ) {
+        pipeline.connection.destroy();
+      }
+      if (signal.aborted) {
+        return;
+      } else {
+        throw err;
+      }
+    }),
+  ]);
+
+  if (signal.aborted) {
+    await interaction.editReply("ボイスチャンネルに接続できませんでした。");
+    return;
+  }
   await interaction.editReply(`${channel}に参加しました。`);
 }

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -38,6 +38,9 @@ export async function handler(
       "ボイスチャンネルに参加するか、チャンネルを指定してください。",
     );
   }
+  if (!channel.joinable) {
+    throw new ReplyableError("ボイスチャンネルに接続する権限がありません。");
+  }
   if (Pipeline.get(channel.guildId) != null) {
     throw new ReplyableError("すでにボイスチャンネルに接続しています。");
   }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -86,10 +86,10 @@ export default class Pipeline extends EventEmitter {
       this.play();
     });
     this.on("disconnect", () => {
-      this.destroy();
+      this.connection.destroy();
     });
     this.on("destroy", () => {
-      Pipeline.#cache.delete(this.channel.guild.id);
+      this.destroy();
     });
     this.on("message", (message) => {
       synthesizer.dispatchSynthesis(message);
@@ -112,7 +112,7 @@ export default class Pipeline extends EventEmitter {
   }
 
   destroy() {
-    this.connection.destroy();
+    Pipeline.#cache.delete(this.channel.guild.id);
     this.player.stop(true);
     this.collector.stop();
   }


### PR DESCRIPTION
fix #55 
fix #56 
fix #57
# 問題
1つのメッセージが読み上げられる回数がbotをvcから抜けさせて再接続するごとに増えていく。

# 原因
#55: 原因はMessageCollectorがleaveコマンド実行時に適切に終了されなかったことで、`Synthesizer#dispatchSynthesis`がleaveコマンドの実行回数+1回呼ばれていたこと。
#56,#57: ハンドリングしてない
# 解決
VoiceConnectionのライフサイクルを考慮して適切になるようにdestroy時に呼ばれる処理を修正し、その他Pipelineのライフサイクルが適切になるように修正した。

# このPRの意図した挙動
- botがすでにVCに接続している=>エラーメッセージを直ちに返す
- botがVCに接続できない=>権限の不足でエラーにできる場合は直ちにエラーにし、できない場合には15s後にエラーメッセージを返す
- botが切断させられる=>切断する
- botがチャンネル移動させられる=>切断する