### PR TITLE
deps: update node-altjtalk-binding to v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@discordjs/opus": "0.9.0",
         "@discordjs/voice": "0.16.1",
         "discord.js": "14.14.1",
-        "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.3/node.tar.gz",
+        "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.4/node.tar.gz",
         "sodium-native": "4.0.4"
       },
       "devDependencies": {
@@ -3289,9 +3289,9 @@
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/node-altjtalk-binding": {
-      "version": "0.1.3",
-      "resolved": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.3/node.tar.gz",
-      "integrity": "sha512-ye2dgJ3ZuKs/lv7eG5D0xU9LB+RcAw7bkB3/IXW/LxFEA/KSw1QnW9tDOIxJD4to2c3wF2AWfiAcgZIAOj+/SA==",
+      "version": "0.1.4",
+      "resolved": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.4/node.tar.gz",
+      "integrity": "sha512-foGqvAcLt5BECPKMo99Gg0SAApnKcR3xT9t3UQH4bG6JiWNKnZ0syWyOlIkOxuhAn1tThaS2fYbJXZEtXCKzkg==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@discordjs/opus": "0.9.0",
     "@discordjs/voice": "0.16.1",
     "discord.js": "14.14.1",
-    "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.3/node.tar.gz",
+    "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.4/node.tar.gz",
     "sodium-native": "4.0.4"
   }
 }


### PR DESCRIPTION
node-altjtalk-bindingを0.1.4にアップデートします．
Windowsでインストールできない問題と，上流のjpreprocessのバグ（「――酒」の酒が読み上げられない件）が修正されます．