### PR TITLE
fix: default import SimpleMarkdown

### DIFF
--- a/src/synthesis/clean.ts
+++ b/src/synthesis/clean.ts
@@ -1,6 +1,6 @@
 import { parse, rules } from "discord-markdown-parser";
 import type { Guild, Message } from "discord.js";
-import { parserFor } from "simple-markdown";
+import SimpleMarkdown from "simple-markdown";
 import type { SingleASTNode, ASTNode } from "simple-markdown";
 
 export function cleanMarkdown(message: Message) {
@@ -160,7 +160,7 @@ function parseDiscordUrl(url: string): DiscordUrl | undefined {
   } catch {}
 }
 
-const twemojiParser = parserFor(
+const twemojiParser = SimpleMarkdown.parserFor(
   { twemoji: rules.twemoji, text: rules.text },
   { inline: true },
 );


### PR DESCRIPTION
```
SyntaxError: Named export 'parserFor' not found. The requested module 'simple-markdown' is a CommonJS module, which may not support all module.exports as named exports.
```