### PR TITLE
build: add variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG NODE_ENV=production
 WORKDIR /app
 RUN npm config set cache /.npm
 COPY ./package*.json ./
-RUN --mount=type=cache,target=/.npm \
+RUN --mount=type=cache,id=npm-$TARGETPLATFORM,target=/.npm \
     npm ci
 
 FROM --platform=$BUILDPLATFORM node:20.10.0-bookworm AS builder
@@ -14,7 +14,7 @@ WORKDIR /app
 RUN npm config set cache /.npm
 COPY ./build.js ./
 COPY ./package*.json ./
-RUN --mount=type=cache,target=/.npm \
+RUN --mount=type=cache,id=npm-$TARGETPLATFORM,target=/.npm \
     npm ci
 COPY ./src/ ./src/
 RUN npm run build


### PR DESCRIPTION
multi-platform imagesをビルドするときに、cacheが使われるようにする