### PR TITLE
deps: Update node-altjtalk-binding to v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@discordjs/voice": "0.16.1",
         "discord-markdown-parser": "1.1.0",
         "discord.js": "14.14.1",
-        "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.6/node.tar.gz",
+        "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.2.0/node.tar.gz",
         "simple-markdown": "0.7.3",
         "sodium-native": "4.0.4"
       },
@@ -3940,9 +3940,9 @@
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/node-altjtalk-binding": {
-      "version": "0.1.6",
-      "resolved": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.6/node.tar.gz",
-      "integrity": "sha512-bgR67hRIadXlUuFEtAYPc2pNfWuXUdvAdmKy0utc4VtqFqk3DxnQDQz1pg8ZAwLvwNUT7k1/W5NKus2yoXnTIQ==",
+      "version": "0.2.0",
+      "resolved": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.2.0/node.tar.gz",
+      "integrity": "sha512-ATvvxT0UmszFSsyIhKWES7g3y09icWg6K977UXVrAJ2nt2W3OrkHbYpdwRVTVBPw7B/zxsSng/h0L/JPljHElw==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@discordjs/voice": "0.16.1",
     "discord-markdown-parser": "1.1.0",
     "discord.js": "14.14.1",
-    "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.1.6/node.tar.gz",
+    "node-altjtalk-binding": "https://github.com/femshima/node-altjtalk-binding/releases/download/v0.2.0/node.tar.gz",
     "simple-markdown": "0.7.3",
     "sodium-native": "4.0.4"
   }

--- a/src/synthesis/common.ts
+++ b/src/synthesis/common.ts
@@ -16,7 +16,13 @@ export function isAltJTalkConfigValid(arg: unknown): arg is AltJTalkConfig {
     "dictionary" in arg &&
     "models" in arg &&
     typeof arg.dictionary === "string" &&
-    Array.isArray(arg.models) &&
-    arg.models.every((s) => typeof s === "string")
+    isStringArray(arg.models)
+  );
+}
+
+export function isStringArray(arg: unknown): arg is string[] {
+  return (
+    Array.isArray(arg) &&
+    arg.every((elem): elem is string => typeof elem === "string")
   );
 }

--- a/src/synthesis/common.ts
+++ b/src/synthesis/common.ts
@@ -14,8 +14,9 @@ export function isAltJTalkConfigValid(arg: unknown): arg is AltJTalkConfig {
     typeof arg === "object" &&
     arg !== null &&
     "dictionary" in arg &&
-    "model" in arg &&
+    "models" in arg &&
     typeof arg.dictionary === "string" &&
-    typeof arg.model === "string"
+    Array.isArray(arg.models) &&
+    arg.models.every((s) => typeof s === "string")
   );
 }

--- a/src/synthesis/index.ts
+++ b/src/synthesis/index.ts
@@ -1,16 +1,11 @@
+import { isStringArray } from "./common";
 import type { Synthesizer } from "./synthesizer";
 import WorkerSynthesizer from "./worker-synthesizer";
 
 function parseStringArray(arg: string) {
   const data: unknown = JSON.parse(arg);
-  if (
-    Array.isArray(data) &&
-    data.every((elem): elem is string => typeof elem === "string")
-  ) {
-    return data;
-  } else {
-    throw new Error(`${arg} is not array of string`);
-  }
+  if (isStringArray(data)) return data;
+  else throw new Error(`${arg} is not array of string`);
 }
 
 export const synthesizer: Synthesizer = new WorkerSynthesizer(

--- a/src/synthesis/index.ts
+++ b/src/synthesis/index.ts
@@ -1,7 +1,24 @@
 import type { Synthesizer } from "./synthesizer";
 import WorkerSynthesizer from "./worker-synthesizer";
 
+function parseStringArray(arg: string) {
+  const data: unknown = JSON.parse(arg);
+  if (
+    Array.isArray(data) &&
+    data.every((elem): elem is string => typeof elem === "string")
+  ) {
+    return data;
+  } else {
+    throw new Error(`${arg} is not array of string`);
+  }
+}
+
 export const synthesizer: Synthesizer = new WorkerSynthesizer(
   process.env.DICTIONARY ?? "model/naist-jdic",
-  process.env.MODEL ?? "model/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice",
+  process.env.DICTIONARY
+    ? process.env.USER_DICTIONARY
+    : "model/user-dictionary.bin",
+  process.env.MODEL
+    ? parseStringArray(process.env.MODEL)
+    : ["model/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice"],
 );

--- a/src/synthesis/index.ts
+++ b/src/synthesis/index.ts
@@ -11,7 +11,7 @@ function parseStringArray(arg: string) {
 export const synthesizer: Synthesizer = new WorkerSynthesizer(
   process.env.DICTIONARY ?? "model/naist-jdic",
   process.env.USER_DICTIONARY,
-  process.env.MODEL
-    ? parseStringArray(process.env.MODEL)
+  process.env.MODELS
+    ? parseStringArray(process.env.MODELS)
     : ["model/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice"],
 );

--- a/src/synthesis/index.ts
+++ b/src/synthesis/index.ts
@@ -15,9 +15,7 @@ function parseStringArray(arg: string) {
 
 export const synthesizer: Synthesizer = new WorkerSynthesizer(
   process.env.DICTIONARY ?? "model/naist-jdic",
-  process.env.DICTIONARY
-    ? process.env.USER_DICTIONARY
-    : "model/user-dictionary.bin",
+  process.env.USER_DICTIONARY,
   process.env.MODEL
     ? parseStringArray(process.env.MODEL)
     : ["model/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice"],

--- a/src/synthesis/worker-synthesizer.ts
+++ b/src/synthesis/worker-synthesizer.ts
@@ -21,13 +21,18 @@ export default class WorkerSynthesizer
 {
   workerPool: WorkerPool<Task, Result, AltJTalkConfig>;
 
-  constructor(dictionary: string, model: string) {
+  constructor(
+    dictionary: string,
+    userDictionary: string | undefined,
+    models: string[],
+  ) {
     super();
     this.workerPool = new WorkerPool(
       new URL("task", import.meta.url),
       {
         dictionary,
-        model,
+        userDictionary,
+        models,
       },
       process.env.NUM_THREADS ? Number(process.env.NUM_THREADS) : 1,
     );


### PR DESCRIPTION
バージョンが変わる以外の主要な変更点
- 環境変数`MODEL`が`MODELS`に変わり，書式が`string[]`のJSONになります．
  - 複数のモデルを指定できるようになります．
  - 同時に使えるモデルの組み合わせには制限があります．tohoku-f01のneutral/happy/sad/angryは同時に使えるはずです．
- `USER_DICTIONARY`環境変数を介して，ユーザー辞書を使えるようになります．