### PR TITLE
ci: publish Docker image before releasing

### DIFF
--- a/.github/.config/release-please-config.json
+++ b/.github/.config/release-please-config.json
@@ -68,7 +68,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "include-component-in-tag": false,
       "pull-request-title-pattern": "release: v${version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           config-file: .github/.config/release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: ${{ startsWith(github.event.head_commit.message, 'release:') && github.event.head_commit.author.name == 'github-actions[bot]' }}
 
   docker-publish:
     needs: release-please
@@ -30,6 +31,18 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag-name: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: [release-please, docker-publish]
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh release edit ${{ needs.release-please.outputs.tag_name }} --draft=false
 
   label-published:
     needs: [release-please, docker-publish]


### PR DESCRIPTION
コンテナイメージの publish が終わってからリリースを行うようにします