### PR TITLE
build: Switch from Import Assertions to Import Attributes

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 import { build } from "esbuild";
 import { esbuildPluginVersionInjector } from "esbuild-plugin-version-injector";
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 await build({
   entryPoints: [


### PR DESCRIPTION
Node.js v20.10.0 にて Import attributes に変更されました
see: https://nodejs.org/docs/v20.12.0/api/esm.html#import-attributes