### PR TITLE
chore: remove `container_name` specification

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,6 @@
 services:
   om:
     image: discordjs-japan-om
-    container_name: discordjs-japan-om
     build: .
     env_file: .env
     pull_policy: build


### PR DESCRIPTION
Makes it possible to avoid container name conflicts.
