### PR TITLE
chore(husky): `npx` is no longer needed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged


### PR DESCRIPTION
ref: https://github.com/typicode/husky/releases/tag/v9.1.1
