### PR TITLE
chore: exclude scripts directory from linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 /.husky/install.mjs linguist-vendored
 
 /*.config.* -linguist-detectable
-/build.js -linguist-detectable
+/scripts/** -linguist-detectable


### PR DESCRIPTION
related: #686 