### PR TITLE
fix: fix a bug of dateSegments()

### DIFF
--- a/src/synthesis/clean.test.ts
+++ b/src/synthesis/clean.test.ts
@@ -226,4 +226,16 @@ void test("cleanMarkdown works fine with timestamp", () => {
     ),
     "2018年1月1日月曜日 0時0分0秒",
   );
+  assert.strictEqual(
+    cleanMarkdown(
+      mockMessage(`<t:${timestamp("+010000-01-01T08:59:00.000+0900")}>`),
+    ),
+    "10000年1月1日土曜日 8時59分0秒",
+  );
+  assert.strictEqual(
+    cleanMarkdown(
+      mockMessage(`<t:${timestamp("+275760-09-13T09:00:00.000+0900")}>`),
+    ),
+    "275760年9月13日土曜日 9時0分0秒",
+  );
 });

--- a/src/synthesis/clean.ts
+++ b/src/synthesis/clean.ts
@@ -195,7 +195,7 @@ function cleanTwemojis(s: string) {
 function dateSegments(date: number | Date) {
   const segments = dateTimeFormat
     .formatToParts(date)
-    .reduce((accumulator, { type, value }) => {
+    .reduce<string[]>((accumulator, { type, value }) => {
       switch (type) {
         case "year":
         case "month":

--- a/src/synthesis/clean.ts
+++ b/src/synthesis/clean.ts
@@ -219,7 +219,7 @@ function dateSegments(date: number | Date) {
           break;
       }
       return accumulator;
-    }, [] as string[]);
+    }, []);
   segments[segments.length - 1] = segments[segments.length - 1].trimEnd();
   return segments;
 }

--- a/src/synthesis/clean.ts
+++ b/src/synthesis/clean.ts
@@ -193,8 +193,33 @@ function cleanTwemojis(s: string) {
 }
 
 function dateSegments(date: number | Date) {
-  const matches = dateTimeFormat.format(date).matchAll(/\d+[^\d]+(?=[\d ])/g);
-  return Array.from(matches, ({ 0: segment }) =>
-    segment.replace(/^0(\d)/, "$1"),
-  );
+  const segments = dateTimeFormat
+    .formatToParts(date)
+    .reduce((accumulator, { type, value }) => {
+      switch (type) {
+        case "year":
+        case "month":
+        case "day":
+        case "hour":
+        case "minute":
+        case "second": {
+          // remove leading 0
+          const val = +value;
+          accumulator.push(Number.isNaN(val) ? value : `${val}`);
+          break;
+        }
+        case "weekday":
+        case "literal":
+          if (accumulator.length === 0) {
+            accumulator.push(value);
+          } else {
+            // string-concatenatation
+            accumulator[accumulator.length - 1] += value;
+          }
+          break;
+      }
+      return accumulator;
+    }, [] as string[]);
+  segments[segments.length - 1] = segments[segments.length - 1].trimEnd();
+  return segments;
 }


### PR DESCRIPTION
`<t:253402300740>` などを読み上げる際，最後に「GMTたす9」がつくバグの修正。