### PR TITLE
fix: add *.discordapp.com to allowed host list

### DIFF
--- a/src/synthesis/clean.test.ts
+++ b/src/synthesis/clean.test.ts
@@ -95,6 +95,18 @@ void test("cleanMarkdown works fine with url", () => {
     " 外部サーバーのチャンネル ",
   );
   assert.strictEqual(
+    cleanMarkdown(mockMessage("https://discordapp.com/channels/0/0")),
+    " 外部サーバーのチャンネル ",
+  );
+  assert.strictEqual(
+    cleanMarkdown(mockMessage("https://ptb.discordapp.com/channels/0/0")),
+    " 外部サーバーのチャンネル ",
+  );
+  assert.strictEqual(
+    cleanMarkdown(mockMessage("https://canary.discordapp.com/channels/0/0")),
+    " 外部サーバーのチャンネル ",
+  );
+  assert.strictEqual(
     cleanMarkdown(mockMessage("https://discord.com/channels/0/0/0")),
     " 外部サーバーのメッセージ ",
   );

--- a/src/synthesis/clean.ts
+++ b/src/synthesis/clean.ts
@@ -170,7 +170,14 @@ function parseDiscordUrl(url: string): DiscordUrl | undefined {
     const { protocol, host, pathname } = new URL(url);
     if (protocol !== "https:") return;
     if (
-      !["discord.com", "ptb.discord.com", "canary.discord.com"].includes(host)
+      ![
+        "discord.com",
+        "ptb.discord.com",
+        "canary.discord.com",
+        "discordapp.com",
+        "ptb.discordapp.com",
+        "canary.discordapp.com",
+      ].includes(host)
     )
       return;
 


### PR DESCRIPTION
クライアントでは discordapp.com でも discord のリンクであると判断されるため，それらを追加。