### PR TITLE
chore(deps-dev): remove unnecessary @types/eslint__js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       },
       "devDependencies": {
         "@eslint/js": "9.21.0",
-        "@types/eslint__js": "9.14.0",
         "@types/eslint-config-prettier": "6.11.3",
         "@types/node": "22.13.5",
         "esbuild": "0.25.0",
@@ -912,17 +911,6 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint__js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-9.14.0.tgz",
-      "integrity": "sha512-s0jepCjOJWB/GKcuba4jISaVpBudw3ClXJ3fUK4tugChUMQsp6kSwuA8Dcx6wFd/JsJqcY8n4rEpa5RTHs5ypA==",
-      "deprecated": "This is a stub types definition. @eslint/js provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/js": "*"
-      }
     },
     "node_modules/@types/eslint-config-prettier": {
       "version": "6.11.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "9.21.0",
-    "@types/eslint__js": "9.14.0",
     "@types/eslint-config-prettier": "6.11.3",
     "@types/node": "22.13.5",
     "esbuild": "0.25.0",


### PR DESCRIPTION
This package is a stub type definition and is not needed because @eslint/js provides its own type definitions.