### PR TITLE
chore: update eslint-config-prettier import to use `/flat` entry

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import eslint from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
+import eslintConfigPrettier from "eslint-config-prettier/flat";
 import eslintPluginImportX from "eslint-plugin-import-x";
 import globals from "globals";
 import tseslint from "typescript-eslint";


### PR DESCRIPTION
see: https://github.com/prettier/eslint-config-prettier/blob/v10.1.1/CHANGELOG.md#patch-changes
