### PR TITLE
ci(deps): migrate from attest-build-provenance to actions/attest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -177,7 +177,7 @@ jobs:
           echo digest=$(docker buildx imagetools inspect ${{ needs.env.outputs.REGISTRY_IMAGE }}:${{ needs.meta.outputs.version }} --format='{{json .Manifest.Digest}}') >> $GITHUB_OUTPUT
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ needs.env.outputs.REGISTRY_IMAGE }}
           subject-digest: ${{ fromJson(steps.get-image-digest.outputs.digest) }}


### PR DESCRIPTION
Update the attestation action to use actions/attest as actions/attest-build-provenance is now a wrapper around it.
