### PR TITLE
ci: grant artifact metadata permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag-name: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
Pass artifact-metadata: write to the reusable Docker publish workflow.

Regression from: https://github.com/discordjs-japan/om/commit/8255755c2d37c10262c8dbfee9e8f1b42aaf8869
Related PR: https://github.com/discordjs-japan/om/pull/1346
